### PR TITLE
Add permissions boundary to integration test resources stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ destroy: venv
 
 ## ci-synth: Run CDK synth for integration stack
 ci-synth: venv
-	$(TOX) $(RECREATE) -e dev -- deploy '*' --app cdk/app_ci.py
+	$(TOX) $(RECREATE) -e dev -- synth '*' --app cdk/app_ci.py
 
 ## ci-deploy: Run CDK deploy for integration stack
 ci-deploy: venv

--- a/README.md
+++ b/README.md
@@ -121,7 +121,10 @@ the following commands to install the required packages:
 
 ```plain
 sudo apt update
-sudo apt install -y --no-install-recommends make python3.9-dev tox
+sudo apt install -y --no-install-recommends make python3.9-dev
+python -m pip install "tox>=3.18,<4"
+# See https://github.com/pypa/virtualenv/issues/1873#issuecomment-648956938
+python -m pip install --force-reinstall "virtualenv==20.0.23"
 ```
 
 Next, you must clone this repository, but to do so, you need to create a GitHub personal

--- a/cdk/app_ci.py
+++ b/cdk/app_ci.py
@@ -9,7 +9,11 @@ from stacks import HlsLpdaacIntegrationStack, HlsLpdaacStack
 ci_app = cdk.App()
 account_id = iam.AccountRootPrincipal().account_id
 
-int_stack = HlsLpdaacIntegrationStack(ci_app, "integration-test-resources")
+int_stack = HlsLpdaacIntegrationStack(
+    ci_app,
+    "integration-test-resources",
+    managed_policy_name="mcp-tenantOperator",
+)
 stack_under_test = HlsLpdaacStack(
     ci_app,
     "hls-lpdaac-under-test",

--- a/cdk/app_ci.py
+++ b/cdk/app_ci.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_ssm as ssm
@@ -6,20 +7,22 @@ from aws_cdk import core as cdk
 
 from stacks import HlsLpdaacIntegrationStack, HlsLpdaacStack
 
+managed_policy_name = os.getenv("HLS_LPDAAC_MANAGED_POLICY_NAME")
+
 ci_app = cdk.App()
 account_id = iam.AccountRootPrincipal().account_id
 
 int_stack = HlsLpdaacIntegrationStack(
     ci_app,
     "integration-test-resources",
-    managed_policy_name="mcp-tenantOperator",
+    managed_policy_name=managed_policy_name,
 )
 stack_under_test = HlsLpdaacStack(
     ci_app,
     "hls-lpdaac-under-test",
     bucket_name=int_stack.bucket.bucket_name,
     queue_arn=int_stack.queue.queue_arn,
-    managed_policy_name="mcp-tenantOperator",
+    managed_policy_name=managed_policy_name,
 )
 
 # Set SSM Parameter for use within integration tests


### PR DESCRIPTION
Added a permissions boundary to the integration test resources stack, which appears to be responsible for at least a few of the OIDC policy problems.