### PR TITLE
Run integration tests on PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,7 +115,6 @@ jobs:
             'to_entries|map("\(.key)=\(.value)\u0000")[]')
       - name: Run integration tests
         run: |
-          env
           # Ensure stack is destroyed at exit, even if tests fail
           trap "make ci-destroy" EXIT
           make ci-deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,6 +104,15 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_ARN }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Export secrets as environment variables
+        env:
+          SECRETS_CONTEXT: ${{ toJson(secrets) }}
+        run: |
+          while read -rd $'' line
+          do
+            echo "$line" >> $GITHUB_ENV
+          done < <(jq -r <<<"$SECRETS_CONTEXT" \
+            'to_entries|map("\(.key)=\(.value)\u0000")[]')
       - name: Run integration tests
         run: |
           # Ensure stack is destroyed at exit, even if tests fail

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ on:
     tags-ignore:
       - '*'
     paths:
+      - '.github/workflows/*'
       - 'cdk/**'
       - 'src/**'
       - 'cdk.json'
@@ -31,6 +32,7 @@ on:
       - main
       - develop
     paths:
+      - '.github/workflows/*'
       - 'cdk/**'
       - 'src/**'
       - 'cdk.json'
@@ -84,10 +86,6 @@ jobs:
           make unit-tests
 
   integration-tests:
-    # Run integration tests only on "push" or "release", which means only on
-    # `develop` or `main` branches, because the OIDC role in MCP trusts only
-    # those 2 branches.
-    if: github.event_name == 'push' || github.event_name == 'release'
     runs-on: ubuntu-22.04
     environment: dev
     needs: config
@@ -108,9 +106,9 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Run integration tests
         run: |
-          make ci-deploy
           # Ensure stack is destroyed at exit, even if tests fail
           trap "make ci-destroy" EXIT
+          make ci-deploy
           make integration-tests
 
   deploy-dev:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,6 +115,7 @@ jobs:
             'to_entries|map("\(.key)=\(.value)\u0000")[]')
       - name: Run integration tests
         run: |
+          env
           # Ensure stack is destroyed at exit, even if tests fail
           trap "make ci-destroy" EXIT
           make ci-deploy

--- a/cdk/app_ci.py
+++ b/cdk/app_ci.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import os
 
-from aws_cdk import aws_iam as iam
 from aws_cdk import aws_ssm as ssm
 from aws_cdk import core as cdk
 
@@ -10,7 +9,6 @@ from stacks import HlsLpdaacIntegrationStack, HlsLpdaacStack
 managed_policy_name = os.getenv("HLS_LPDAAC_MANAGED_POLICY_NAME")
 
 ci_app = cdk.App()
-account_id = iam.AccountRootPrincipal().account_id
 
 int_stack = HlsLpdaacIntegrationStack(
     ci_app,

--- a/cdk/stacks/hls_lpdaac_stack.py
+++ b/cdk/stacks/hls_lpdaac_stack.py
@@ -20,8 +20,6 @@ class HlsLpdaacStack(cdk.Stack):
     ) -> None:
         super().__init__(scope, stack_name)
 
-        print(f"MANAGED POLICY NAME: {managed_policy_name}")
-
         if managed_policy_name:
             iam.PermissionsBoundary.of(self).apply(
                 iam.ManagedPolicy.from_managed_policy_name(

--- a/cdk/stacks/hls_lpdaac_stack.py
+++ b/cdk/stacks/hls_lpdaac_stack.py
@@ -20,14 +20,14 @@ class HlsLpdaacStack(cdk.Stack):
     ) -> None:
         super().__init__(scope, stack_name)
 
-        if managed_policy_name:
-            account_id = iam.AccountRootPrincipal().account_id
+        print(f"MANAGED POLICY NAME: {managed_policy_name}")
 
+        if managed_policy_name:
             iam.PermissionsBoundary.of(self).apply(
-                iam.ManagedPolicy.from_managed_policy_arn(
+                iam.ManagedPolicy.from_managed_policy_name(
                     self,
                     "PermissionsBoundary",
-                    f"arn:aws:iam::{account_id}:policy/{managed_policy_name}",
+                    managed_policy_name,
                 )
             )
 

--- a/cdk/stacks/hls_lpdaac_stack_ci.py
+++ b/cdk/stacks/hls_lpdaac_stack_ci.py
@@ -32,11 +32,7 @@ class HlsLpdaacIntegrationStack(cdk.Stack):
             removal_policy=cdk.RemovalPolicy.DESTROY,
             # auto_delete_objects=True,
         )
-        self.queue = sqs.Queue(
-            self,
-            "test-queue",
-            removal_policy=cdk.RemovalPolicy.DESTROY,
-        )
+        self.queue = sqs.Queue(self, "test-queue")
 
         # Set SSM Parameters for use within integration tests
 

--- a/cdk/stacks/hls_lpdaac_stack_ci.py
+++ b/cdk/stacks/hls_lpdaac_stack_ci.py
@@ -17,8 +17,6 @@ class HlsLpdaacIntegrationStack(cdk.Stack):
     ) -> None:
         super().__init__(scope, id)
 
-        print(f"MANAGED POLICY NAME: {managed_policy_name}")
-
         if managed_policy_name:
             iam.PermissionsBoundary.of(self).apply(
                 iam.ManagedPolicy.from_managed_policy_name(

--- a/cdk/stacks/hls_lpdaac_stack_ci.py
+++ b/cdk/stacks/hls_lpdaac_stack_ci.py
@@ -17,14 +17,14 @@ class HlsLpdaacIntegrationStack(cdk.Stack):
     ) -> None:
         super().__init__(scope, id)
 
-        if managed_policy_name:
-            account_id = iam.AccountRootPrincipal().account_id
+        print(f"MANAGED POLICY NAME: {managed_policy_name}")
 
+        if managed_policy_name:
             iam.PermissionsBoundary.of(self).apply(
-                iam.ManagedPolicy.from_managed_policy_arn(
+                iam.ManagedPolicy.from_managed_policy_name(
                     self,
                     "PermissionsBoundary",
-                    f"arn:aws:iam::{account_id}:policy/{managed_policy_name}",
+                    managed_policy_name,
                 )
             )
 

--- a/tests/integration/test_historical_lambda.py
+++ b/tests/integration/test_historical_lambda.py
@@ -29,9 +29,9 @@ def test_notification(
 
     # Write S3 Object with .v2.0.json suffix to source bucket to trigger notification.
     body = '{ "greeting": "hello world!" }'
-    object = bucket.Object("greeting.v2.0.json")
-    object.put(Body=body)
-    object.wait_until_exists()
+    obj = bucket.Object("greeting.v2.0.json")
+    obj.put(Body=body)
+    obj.wait_until_exists()
 
     try:
         # Wait for lambda function to succeed, which should be triggered by S3
@@ -46,8 +46,8 @@ def test_notification(
         messages = queue.receive_messages(WaitTimeSeconds=20)
     finally:
         # Cleanup S3 Object with .v2.0.json suffix from source bucket.
-        object.delete()
-        object.wait_until_not_exists()
+        obj.delete()
+        obj.wait_until_not_exists()
 
     # Assert message contents == S3 Object contents (written above)
     assert len(messages) == 1


### PR DESCRIPTION
- To avoid having to wait for PR approval and merging to `develop` or `main`, run integration tests when PR is opened or updated.
- Ensure integration test resources are destroyed even when the stack under test fails to deploy.