### PR TITLE
Make tiler queue var optional

### DIFF
--- a/cdk/app_forward.py
+++ b/cdk/app_forward.py
@@ -9,10 +9,13 @@ from stacks import ForwardNotificationStack
 stack_name = os.environ["HLS_LPDAAC_STACK"]
 bucket_name = os.environ["HLS_LPDAAC_BUCKET_NAME"]
 queue_arn = os.environ["HLS_LPDAAC_QUEUE_ARN"]
-tiler_queue_arn = os.environ["HLS_LPDAAC_TILER_QUEUE_ARN"]
 
 # Optional environment variables
 managed_policy_name = os.getenv("HLS_LPDAAC_MANAGED_POLICY_NAME")
+# Optional, but if it is not provided, the tiler queue will be created, which
+# is what we want in all environments except production since there is only a
+# single tiler queue.
+tiler_queue_arn = os.getenv("HLS_LPDAAC_TILER_QUEUE_ARN")
 
 app = cdk.App()
 

--- a/cdk/stacks/forward_notification.py
+++ b/cdk/stacks/forward_notification.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda as lambda_
@@ -16,7 +16,7 @@ class NotificationStack(cdk.Stack):
         *,
         bucket_name: str,
         lpdaac_queue_arn: str,
-        tiler_queue_arn: str,
+        tiler_queue_arn: Optional[str] = None,
         managed_policy_name: Optional[str] = None,
     ) -> None:
         super().__init__(scope, stack_name)
@@ -36,8 +36,10 @@ class NotificationStack(cdk.Stack):
         self.lpdaac_queue = sqs.Queue.from_queue_arn(
             self, "lpdaac", queue_arn=lpdaac_queue_arn
         )
-        self.tiler_queue = sqs.Queue.from_queue_arn(
-            self, "tiler", queue_arn=tiler_queue_arn
+        self.tiler_queue: Union[sqs.Queue, sqs.IQueue] = (
+            sqs.Queue(self, "tiler", retention_period=cdk.Duration.minutes(5))
+            if tiler_queue_arn is None
+            else sqs.Queue.from_queue_arn(self, "tiler", queue_arn=tiler_queue_arn)
         )
         self.notification_function = lambda_.Function(
             self,


### PR DESCRIPTION
If no value is supplied for the env var HLS_LPDAAC_TILER_QUEUE_ARN, a dummy queue will be created and used. This is necessary because there is only such a queue in production, so other envs need a dummy queue.