### PR TITLE
Bump CDK CLI and Node versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 APPS=$(subst _,-,$(patsubst cdk/app_%.py,%,$(wildcard cdk/app_*.py)))
 IT_APPS=$(subst _,-,$(patsubst cdk/app_%.py,%,$(wildcard cdk/app_*_it.py)))
-CDK_VERSION=2.137.0
-NODE_VERSION=18.18.2
 RECREATE=
 SHELL=/usr/bin/env bash
 TOX=tox $(TOX_OPTS)
@@ -44,18 +42,14 @@ tox:
 	fi
 
 # NOTE: Intended only for use from tox.ini.
-# Install Node.js within the tox virtualenv, if it's not installed or it's the wrong version.
+# Install Node.js within the tox virtualenv.
 install-node: tox
-	@if [[ ! $$(type node 2>/dev/null) =~ $${VIRTUAL_ENV} || ! $$(node -v) =~ $(NODE_VERSION) ]]; then \
-	    set -x; nodeenv --node $(NODE_VERSION) --python-virtualenv; \
-	fi
+	nodeenv --node lts --python-virtualenv
 
 # NOTE: Intended only for use from tox.ini
-# Install the CDK CLI within the tox virtualenv, if it's not installed or it's the wrong version.
+# Install the CDK CLI within the tox virtualenv.
 install-cdk: install-node
-	@if [[ ! $$(type cdk 2>/dev/null) =~ $${VIRTUAL_ENV} || ! $$(cdk --version) =~ $(CDK_VERSION) ]]; then \
-	    set -x; npm install --location global "aws-cdk@$(CDK_VERSION)"; \
-	fi
+	npm install --location global "aws-cdk@latest"
 
 ## bootstrap: Bootstrap the CDK toolkit
 bootstrap:

--- a/src/hls_lpdaac/forward/index.py
+++ b/src/hls_lpdaac/forward/index.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import boto3
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from aws_lambda_typing.context import Context
     from aws_lambda_typing.events import S3Event
 

--- a/src/hls_lpdaac/historical/index.py
+++ b/src/hls_lpdaac/historical/index.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 import boto3
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from aws_lambda_typing.context import Context
     from aws_lambda_typing.events import S3Event
 

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ exclude =
   __pycache__
   .git
   .tox
-  .venv*
+  .*venv*
   cdk.out
   *.egg-info
 max-line-length = 90


### PR DESCRIPTION
Integration tests deployment failed due to the following:

> This CDK CLI is not compatible with the CDK library used by your application. Please upgrade the CLI to the latest version.
(Cloud assembly schema version mismatch: Maximum schema version supported is 36.0.0, but found 38.0.1)

This PR ensures we always deploy with the latest CDK CLI and Node versions, which should prevent this problem from re-occurring, reducing our maintenance burden.