### PR TITLE
Do not send STAC messages to FIRMS tiler queue for VI data

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
     # Alternative hack: https://github.com/actions/runner/issues/1182#issuecomment-1262870831
     runs-on: ubuntu-22.04
     outputs:
-      PYTHON_VERSION: "3.9"
+      PYTHON_VERSION: "3.12"
       TOX_MIN_VERSION: "3.18.0"  # `allowlist_externals` replaces `whitelist_externals`
     steps:
       - name: Configure shared values

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-default_stages: [commit]
+default_stages: [pre-commit]
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ tox:
 # NOTE: Intended only for use from tox.ini.
 # Install Node.js within the tox virtualenv.
 install-node: tox
-	type node || nodeenv --node lts --python-virtualenv
+	nodeenv --node lts --python-virtualenv
 
 # NOTE: Intended only for use from tox.ini
 # Install the CDK CLI within the tox virtualenv.

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ tox:
 # NOTE: Intended only for use from tox.ini.
 # Install Node.js within the tox virtualenv.
 install-node: tox
-	nodeenv --node lts --python-virtualenv
+	type node || nodeenv --node lts --python-virtualenv
 
 # NOTE: Intended only for use from tox.ini
 # Install the CDK CLI within the tox virtualenv.

--- a/cdk.context.json
+++ b/cdk.context.json
@@ -1,0 +1,5 @@
+{
+  "acknowledged-issue-numbers": [
+    32775
+  ]
+}

--- a/cdk/stacks/forward_notification.py
+++ b/cdk/stacks/forward_notification.py
@@ -47,7 +47,7 @@ class NotificationStack(Stack):
             "ForwardNotifier",
             code=lambda_.Code.from_asset("src/hls_lpdaac/forward"),
             handler="index.handler",
-            runtime=lambda_.Runtime.PYTHON_3_9,  # type: ignore
+            runtime=lambda_.Runtime.PYTHON_3_12,
             memory_size=128,
             timeout=Duration.seconds(30),
             environment=dict(

--- a/cdk/stacks/historical_notification.py
+++ b/cdk/stacks/historical_notification.py
@@ -47,7 +47,7 @@ class NotificationStack(Stack):
             "HistoricalLambda",
             code=lambda_.Code.from_asset("src/hls_lpdaac/historical"),
             handler="index.handler",
-            runtime=lambda_.Runtime.PYTHON_3_9,  # type: ignore
+            runtime=lambda_.Runtime.PYTHON_3_12,
             memory_size=128,
             timeout=Duration.seconds(30),
             environment=dict(QUEUE_URL=self.lpdaac_historical_queue.queue_url),

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extras_require_test = [
     "flake8~=7.0",
     "black~=24.1",
     "boto3~=1.34",
-    "moto[s3,sqs]~=4.0",
+    "moto[s3,sqs]~=5.0",
     "pytest-cov~=4.1",
     "pytest~=8.0",
 ]

--- a/src/hls_lpdaac/forward/index.py
+++ b/src/hls_lpdaac/forward/index.py
@@ -13,7 +13,7 @@ s3 = boto3.resource("s3")
 
 
 def handler(event: "S3Event", _: "Context") -> None:
-    return _handler(
+    return _handler(  # pragma: no cover
         event,
         lpdaac_queue_url=os.environ["LPDAAC_QUEUE_URL"],
         tiler_queue_url=os.environ["TILER_QUEUE_URL"],

--- a/src/hls_lpdaac/forward/index.py
+++ b/src/hls_lpdaac/forward/index.py
@@ -32,9 +32,11 @@ def _handler(event: "S3Event", *, lpdaac_queue_url: str, tiler_queue_url: str) -
     json_contents = s3.Object(bucket, json_key).get()["Body"].read().decode("utf-8")
     _send_message(lpdaac_queue_url, key=json_key, message=json_contents)
 
-    stac_json_key = json_key.replace(".json", "_stac.json")
-    stac_url = f"s3://{bucket}/{stac_json_key}"
-    _send_message(tiler_queue_url, key=stac_json_key, message=stac_url)
+    # Send message to tiler queue ONLY for non-VI files
+    if "_VI/" not in json_key:
+        stac_json_key = json_key.replace(".json", "_stac.json")
+        stac_url = f"s3://{bucket}/{stac_json_key}"
+        _send_message(tiler_queue_url, key=stac_json_key, message=stac_url)
 
 
 def _send_message(queue_url: str, *, key: str, message: str) -> None:

--- a/src/hls_lpdaac/historical/index.py
+++ b/src/hls_lpdaac/historical/index.py
@@ -11,7 +11,7 @@ s3 = boto3.resource("s3")
 
 
 def handler(event: "S3Event", _: "Context") -> None:
-    _handler(event, os.environ["QUEUE_URL"])
+    _handler(event, os.environ["QUEUE_URL"])  # pragma: no cover
 
 
 # Enables unit testing without the need to monkeypatch `os.environ` (which would

--- a/tests/integration/test_forward_lambda.py
+++ b/tests/integration/test_forward_lambda.py
@@ -5,7 +5,7 @@ from typing import Iterator, Sequence
 from mypy_boto3_s3 import S3ServiceResource
 from mypy_boto3_s3.service_resource import Bucket, Object
 from mypy_boto3_sqs import SQSServiceResource
-from mypy_boto3_sqs.service_resource import Message, Queue
+from mypy_boto3_sqs.service_resource import Queue
 from mypy_boto3_ssm import SSMClient
 
 
@@ -39,11 +39,11 @@ def test_notification(
 
     # We expect only 2 messages for the 2 non-VI objects written
     assert len(tiler_messages) == 2
-    assert tiler_messages == [
+    assert set(tiler_messages) == {  # Set comparison ignores potential order difference
         f"s3://{bucket_name}/{obj.key.replace('.json', '_stac.json')}"
         for obj in objects
         if "_VI/" not in obj.key
-    ]
+    }
 
 
 def ssm_param_value(ssm: SSMClient, name: str) -> str:

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,29 @@
+from aws_lambda_typing.events import S3Event
+from mypy_boto3_s3.service_resource import Object
+
+
+def make_s3_event(s3_object: Object) -> S3Event:
+    return {
+        "Records": [
+            {
+                "s3": {
+                    "s3SchemaVersion": "1.0",
+                    "configurationId": "",
+                    "bucket": {
+                        "name": f"{s3_object.bucket_name}",
+                        "ownerIdentity": {
+                            "principalId": "",
+                        },
+                        "arn": "",
+                    },
+                    "object": {
+                        "key": f"{s3_object.key}",
+                        "size": s3_object.content_length,
+                        "eTag": s3_object.e_tag,
+                        "versionId": s3_object.version_id,
+                        "sequencer": "",
+                    },
+                },
+            },
+        ],
+    }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,7 +5,7 @@ from typing import Callable, Iterator
 
 import boto3
 import pytest
-from moto import mock_s3, mock_sqs
+from moto import mock_aws
 from mypy_boto3_s3 import S3ServiceResource
 from mypy_boto3_s3.service_resource import Bucket, Object
 from mypy_boto3_sqs import SQSServiceResource
@@ -24,7 +24,7 @@ def aws_credentials():
 
 @pytest.fixture(scope="function")
 def s3(aws_credentials) -> Iterator[S3ServiceResource]:
-    with mock_s3():
+    with mock_aws():
         yield boto3.resource("s3")
 
 
@@ -49,7 +49,7 @@ def make_s3_object_with_prefix(s3_bucket: Bucket) -> Callable[[str], Object]:
 
 @pytest.fixture(scope="function")
 def sqs(aws_credentials) -> Iterator[SQSServiceResource]:
-    with mock_sqs():
+    with mock_aws():
         yield boto3.resource("sqs")
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,16 +1,15 @@
+from __future__ import annotations
+
 import os
-from typing import TYPE_CHECKING, Iterator
+from typing import Callable, Iterator
 
 import boto3
 import pytest
 from moto import mock_s3, mock_sqs
-
-if TYPE_CHECKING:
-    from aws_lambda_typing.events import S3Event
-    from mypy_boto3_s3 import S3ServiceResource
-    from mypy_boto3_s3.service_resource import Bucket, Object
-    from mypy_boto3_sqs import SQSServiceResource
-    from mypy_boto3_sqs.service_resource import Queue
+from mypy_boto3_s3 import S3ServiceResource
+from mypy_boto3_s3.service_resource import Bucket, Object
+from mypy_boto3_sqs import SQSServiceResource
+from mypy_boto3_sqs.service_resource import Queue
 
 
 @pytest.fixture(scope="function")
@@ -24,13 +23,13 @@ def aws_credentials():
 
 
 @pytest.fixture(scope="function")
-def s3(aws_credentials) -> Iterator["S3ServiceResource"]:
+def s3(aws_credentials) -> Iterator[S3ServiceResource]:
     with mock_s3():
         yield boto3.resource("s3")
 
 
 @pytest.fixture(scope="function")
-def s3_bucket(s3: "S3ServiceResource") -> "Bucket":
+def s3_bucket(s3: S3ServiceResource) -> Bucket:
     bucket = s3.Bucket("mybucket")
     bucket.create()
 
@@ -38,44 +37,22 @@ def s3_bucket(s3: "S3ServiceResource") -> "Bucket":
 
 
 @pytest.fixture(scope="function")
-def s3_object(s3_bucket: "Bucket") -> "Object":
-    return s3_bucket.put_object(Key="myobject.v2.json", Body=bytes("test", "utf-8"))
+def make_s3_object_with_prefix(s3_bucket: Bucket) -> Callable[[str], Object]:
+    def go(prefix: str) -> Object:
+        return s3_bucket.put_object(
+            Key=f"{prefix.rstrip('/')}/myobject.v2.json",
+            Body=bytes("test", "utf-8"),
+        )
+
+    return go
 
 
 @pytest.fixture(scope="function")
-def s3_event(s3_object: "Object") -> "S3Event":
-    return {
-        "Records": [
-            {
-                "s3": {
-                    "s3SchemaVersion": "1.0",
-                    "configurationId": "",
-                    "bucket": {
-                        "name": f"{s3_object.bucket_name}",
-                        "ownerIdentity": {
-                            "principalId": "",
-                        },
-                        "arn": "",
-                    },
-                    "object": {
-                        "key": f"{s3_object.key}",
-                        "size": s3_object.content_length,
-                        "eTag": s3_object.e_tag,
-                        "versionId": s3_object.version_id,
-                        "sequencer": "",
-                    },
-                },
-            },
-        ],
-    }
-
-
-@pytest.fixture(scope="function")
-def sqs(aws_credentials) -> Iterator["SQSServiceResource"]:
+def sqs(aws_credentials) -> Iterator[SQSServiceResource]:
     with mock_sqs():
         yield boto3.resource("sqs")
 
 
 @pytest.fixture(scope="function")
-def sqs_queue(sqs: "SQSServiceResource") -> "Queue":
+def sqs_queue(sqs: SQSServiceResource) -> Queue:
     return sqs.create_queue(QueueName="myqueue")

--- a/tests/unit/test_forward_handler.py
+++ b/tests/unit/test_forward_handler.py
@@ -2,13 +2,20 @@ from __future__ import annotations
 
 from typing import Callable
 
+import pytest
 from mypy_boto3_s3.service_resource import Object
 from mypy_boto3_sqs.service_resource import Queue
 
 from . import make_s3_event
 
 
+@pytest.mark.parametrize(
+    ("prefix", "expect_tiler_message"),
+    (("L30", True), ("S30", True), ("L30_VI", False), ("S30_VI", False)),
+)
 def test_lpdaac_forward_handler(
+    prefix: str,
+    expect_tiler_message: bool,
     make_s3_object_with_prefix: Callable[[str], Object],
     sqs_queue: Queue,
 ) -> None:
@@ -16,7 +23,7 @@ def test_lpdaac_forward_handler(
     # See http://docs.getmoto.org/en/latest/docs/getting_started.html#what-about-those-pesky-imports
     from hls_lpdaac.forward import _handler
 
-    s3_object = make_s3_object_with_prefix("L30/")
+    s3_object = make_s3_object_with_prefix(prefix)
     s3_event = make_s3_event(s3_object)
     _handler(s3_event, lpdaac_queue_url=sqs_queue.url, tiler_queue_url=sqs_queue.url)
 
@@ -27,7 +34,11 @@ def test_lpdaac_forward_handler(
     ]
     expected_messages = [
         s3_object.get()["Body"].read().decode("utf-8"),
-        f"s3://{bucket}/{key.replace('.json', '_stac.json')}",
+        *(
+            [f"s3://{bucket}/{key.replace('.json', '_stac.json')}"]
+            if expect_tiler_message
+            else []
+        ),
     ]
 
     assert messages == expected_messages

--- a/tests/unit/test_forward_handler.py
+++ b/tests/unit/test_forward_handler.py
@@ -29,16 +29,16 @@ def test_lpdaac_forward_handler(
 
     bucket = s3_event["Records"][0]["s3"]["bucket"]["name"]  # type: ignore
     key = s3_event["Records"][0]["s3"]["object"]["key"]  # type: ignore
-    messages = [
+    messages = {
         message.body for message in sqs_queue.receive_messages(MaxNumberOfMessages=10)
-    ]
-    expected_messages = [
+    }
+    expected_messages = {
         s3_object.get()["Body"].read().decode("utf-8"),
         *(
             [f"s3://{bucket}/{key.replace('.json', '_stac.json')}"]
             if expect_tiler_message
             else []
         ),
-    ]
+    }
 
     assert messages == expected_messages

--- a/tests/unit/test_forward_handler.py
+++ b/tests/unit/test_forward_handler.py
@@ -1,22 +1,23 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Callable
 
-if TYPE_CHECKING:
-    from aws_lambda_typing.events import S3Event
-    from mypy_boto3_s3.service_resource import Object
-    from mypy_boto3_sqs.service_resource import Queue
+from mypy_boto3_s3.service_resource import Object
+from mypy_boto3_sqs.service_resource import Queue
+
+from . import make_s3_event
 
 
 def test_lpdaac_forward_handler(
-    s3_event: S3Event,
-    s3_object: Object,
+    make_s3_object_with_prefix: Callable[[str], Object],
     sqs_queue: Queue,
 ) -> None:
     # Import here (rather than at top level) to ensure AWS mocks are established.
     # See http://docs.getmoto.org/en/latest/docs/getting_started.html#what-about-those-pesky-imports
     from hls_lpdaac.forward import _handler
 
+    s3_object = make_s3_object_with_prefix("L30/")
+    s3_event = make_s3_event(s3_object)
     _handler(s3_event, lpdaac_queue_url=sqs_queue.url, tiler_queue_url=sqs_queue.url)
 
     bucket = s3_event["Records"][0]["s3"]["bucket"]["name"]  # type: ignore

--- a/tests/unit/test_historical_handler.py
+++ b/tests/unit/test_historical_handler.py
@@ -1,22 +1,23 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Callable
 
-if TYPE_CHECKING:
-    from aws_lambda_typing.events import S3Event
-    from mypy_boto3_s3.service_resource import Object
-    from mypy_boto3_sqs.service_resource import Queue
+from mypy_boto3_s3.service_resource import Object
+from mypy_boto3_sqs.service_resource import Queue
+
+from . import make_s3_event
 
 
 def test_lpdaac_historical_handler(
-    s3_event: S3Event,
-    s3_object: Object,
+    make_s3_object_with_prefix: Callable[[str], Object],
     sqs_queue: Queue,
 ) -> None:
     # Import here (rather than at top level) to ensure AWS mocks are established.
     # See http://docs.getmoto.org/en/latest/docs/getting_started.html#what-about-those-pesky-imports
     from hls_lpdaac.historical.index import _handler
 
+    s3_object = make_s3_object_with_prefix("L30/")
+    s3_event = make_s3_event(s3_object)
     _handler(s3_event, sqs_queue.url)
     # We expect only 1 message, but we set MaxNumberOfMessages > 1 to allow us
     # to fail the test if there are multiple messages.

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 # `allowlist_externals` introduced in tox 3.18.0 (deprecating `whitelist_externals`)
 minversion = 3.18.0
-envlist = py39
+envlist = py312
 
 [testenv]
-basepython = python3.9
+basepython = python3.12
 # Setting usedevelop to True is necessary to avoid tox bug that otherwise causes
 # the pytest coverage plugin to fail to collect coverage data, issuing the
 # message 'CoverageWarning: No data was collected. (no-data-collected)'
@@ -58,7 +58,7 @@ exclude =
   __pycache__
   .git
   .tox
-  .*venv*
+  *venv*
   cdk.out
   *.egg-info
 max-line-length = 90


### PR DESCRIPTION
In the production stack, STAC item messages are sent to a FIRMS SQS queue. With the addition of the VI products, messages are also sent, but should not be, as there are no VI STAC items.

This PR avoids sending STAC message for VI items.

Further, it include a few changes to keep the stack up to date:

1. Bump python from 3.9 to 3.12 in the lambda functions
2. Bump moto from 4.x to 5.x
3. Replaced deprecated pre-commit stage `[commit]` with `[pre-commit]`

To test the changes you can run the usual unit and integration test steps given in the README.

Fixes #21 