### PR TITLE
fix: remove sending to tiler queue (since it doesn't exist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ export HLS_LPDAAC_STACK=<stack name>
 export HLS_LPDAAC_BUCKET_NAME=<source bucket name>
 export HLS_LPDAAC_QUEUE_ARN=<destination queue ARN>
 # Required ONLY in PROD for FORWARD processing (otherwise, a dummy queue is created)
-export HLS_LPDAAC_TILER_QUEUE_ARN=<tiler queue ARN>
 export HLS_LPDAAC_MANAGED_POLICY_NAME=mcp-tenantOperator
 ```
 

--- a/cdk/app_forward.py
+++ b/cdk/app_forward.py
@@ -12,10 +12,6 @@ queue_arn = os.environ["HLS_LPDAAC_QUEUE_ARN"]
 
 # Optional environment variables
 managed_policy_name = os.getenv("HLS_LPDAAC_MANAGED_POLICY_NAME")
-# Optional, but if it is not provided, the tiler queue will be created, which
-# is what we want in all environments except production since there is only a
-# single tiler queue.
-tiler_queue_arn = os.getenv("HLS_LPDAAC_TILER_QUEUE_ARN")
 
 app = App()
 
@@ -24,7 +20,6 @@ ForwardNotificationStack(
     stack_name,
     bucket_name=bucket_name,
     lpdaac_queue_arn=queue_arn,
-    tiler_queue_arn=tiler_queue_arn,
     managed_policy_name=managed_policy_name,
 )
 

--- a/cdk/app_forward_it.py
+++ b/cdk/app_forward_it.py
@@ -20,7 +20,6 @@ stack_under_test = ForwardNotificationStack(
     "hls-forward-under-test",
     bucket_name=it_stack.bucket.bucket_name,
     lpdaac_queue_arn=it_stack.forward_queue.queue_arn,
-    tiler_queue_arn=it_stack.tiler_queue.queue_arn,
     managed_policy_name=managed_policy_name,
 )
 

--- a/cdk/stacks/forward_notification.py
+++ b/cdk/stacks/forward_notification.py
@@ -17,7 +17,6 @@ class NotificationStack(Stack):
         *,
         bucket_name: str,
         lpdaac_queue_arn: str,
-        tiler_queue_arn: Optional[str] = None,
         managed_policy_name: Optional[str] = None,
     ) -> None:
         super().__init__(scope, stack_name)
@@ -37,11 +36,6 @@ class NotificationStack(Stack):
         self.lpdaac_queue = sqs.Queue.from_queue_arn(
             self, "lpdaac", queue_arn=lpdaac_queue_arn
         )
-        self.tiler_queue: Union[sqs.Queue, sqs.IQueue] = (
-            sqs.Queue(self, "tiler", retention_period=Duration.minutes(5))
-            if tiler_queue_arn is None
-            else sqs.Queue.from_queue_arn(self, "tiler", queue_arn=tiler_queue_arn)
-        )
         self.notification_function = lambda_.Function(
             self,
             "ForwardNotifier",
@@ -52,14 +46,12 @@ class NotificationStack(Stack):
             timeout=Duration.seconds(30),
             environment=dict(
                 LPDAAC_QUEUE_URL=self.lpdaac_queue.queue_url,
-                TILER_QUEUE_URL=self.tiler_queue.queue_url,
             ),
         )
 
         # Wire everything up
 
         self.lpdaac_queue.grant_send_messages(self.notification_function)
-        self.tiler_queue.grant_send_messages(self.notification_function)
         self.bucket.grant_read(self.notification_function)
         self.bucket.add_object_created_notification(
             s3n.LambdaDestination(self.notification_function),  # type: ignore

--- a/cdk/stacks/forward_notification_it.py
+++ b/cdk/stacks/forward_notification_it.py
@@ -34,7 +34,6 @@ class NotificationITStack(Stack):
             auto_delete_objects=True,
         )
         self.forward_queue = sqs.Queue(self, "forward-queue")
-        self.tiler_queue = sqs.Queue(self, "tiler-queue")
 
         # Set SSM Parameters for use within integration tests
 
@@ -50,11 +49,4 @@ class NotificationITStack(Stack):
             "forward-queue-name",
             string_value=self.forward_queue.queue_name,
             parameter_name="/hls/tests/forward-queue-name",
-        )
-
-        ssm.StringParameter(
-            self,
-            "tiler-queue-name",
-            string_value=self.tiler_queue.queue_name,
-            parameter_name="/hls/tests/tiler-queue-name",
         )

--- a/src/hls_lpdaac/forward/index.py
+++ b/src/hls_lpdaac/forward/index.py
@@ -16,13 +16,12 @@ def handler(event: "S3Event", _: "Context") -> None:
     return _handler(  # pragma: no cover
         event,
         lpdaac_queue_url=os.environ["LPDAAC_QUEUE_URL"],
-        tiler_queue_url=os.environ["TILER_QUEUE_URL"],
     )
 
 
 # Enables unit testing without the need to monkeypatch `os.environ` (which would
 # be necessary to test `handler` above).
-def _handler(event: "S3Event", *, lpdaac_queue_url: str, tiler_queue_url: str) -> None:
+def _handler(event: "S3Event", *, lpdaac_queue_url: str) -> None:
     # The S3Event type is not quite correct, so we are forced to ignore a couple
     # of typing errors that would not occur if the type were defined correctly.
     s3_object = event["Records"][0]["s3"]  # type: ignore
@@ -31,12 +30,6 @@ def _handler(event: "S3Event", *, lpdaac_queue_url: str, tiler_queue_url: str) -
     json_key = s3_object["object"]["key"]  # type: ignore
     json_contents = s3.Object(bucket, json_key).get()["Body"].read().decode("utf-8")
     _send_message(lpdaac_queue_url, key=json_key, message=json_contents)
-
-    # Send message to tiler queue ONLY for non-VI files
-    if "_VI/" not in json_key:
-        stac_json_key = json_key.replace(".json", "_stac.json")
-        stac_url = f"s3://{bucket}/{stac_json_key}"
-        _send_message(tiler_queue_url, key=stac_json_key, message=stac_url)
 
 
 def _send_message(queue_url: str, *, key: str, message: str) -> None:

--- a/tests/integration/test_forward_lambda.py
+++ b/tests/integration/test_forward_lambda.py
@@ -19,15 +19,12 @@ def test_notification(
     bucket = s3.Bucket(bucket_name)
     forward_queue_name = ssm_param_value(ssm, "/hls/tests/forward-queue-name")
     forward_queue = sqs.get_queue_by_name(QueueName=forward_queue_name)
-    tiler_queue_name = ssm_param_value(ssm, "/hls/tests/tiler-queue-name")
-    tiler_queue = sqs.get_queue_by_name(QueueName=tiler_queue_name)
 
     body = '{ "greeting": "hello world!" }'
     objects = write_objects(bucket, body)
 
     try:
         forward_messages = list(fetch_messages(forward_queue))
-        tiler_messages = list(fetch_messages(tiler_queue))
     finally:
         # Cleanup S3 Object with .v2.0.json suffix from source bucket.
         for obj in objects:
@@ -36,14 +33,6 @@ def test_notification(
 
     # We expect 4 messages, 2 for regular and 2 for VI
     assert forward_messages == [body] * 4
-
-    # We expect only 2 messages for the 2 non-VI objects written
-    assert len(tiler_messages) == 2
-    assert set(tiler_messages) == {  # Set comparison ignores potential order difference
-        f"s3://{bucket_name}/{obj.key.replace('.json', '_stac.json')}"
-        for obj in objects
-        if "_VI/" not in obj.key
-    }
 
 
 def ssm_param_value(ssm: SSMClient, name: str) -> str:
@@ -55,8 +44,7 @@ def ssm_param_value(ssm: SSMClient, name: str) -> str:
 
 def write_objects(bucket: Bucket, body: str) -> Sequence[Object]:
     # Write S3 Objects with .v2.0.json suffix to source bucket to trigger notification.
-    # We expect 4 messages in the forward queue and 2 in the tiler queue because the
-    # tiler queue should not send messages for VI.
+    # We expect 4 messages in the forward queue
 
     objects = [
         bucket.Object(f"{prefix}/greeting.v2.0.json")

--- a/tests/unit/test_forward_handler.py
+++ b/tests/unit/test_forward_handler.py
@@ -10,12 +10,11 @@ from . import make_s3_event
 
 
 @pytest.mark.parametrize(
-    ("prefix", "expect_tiler_message"),
-    (("L30", True), ("S30", True), ("L30_VI", False), ("S30_VI", False)),
+    "prefix",
+    ["L30", "S30", "L30_VI", "S30_VI"],
 )
 def test_lpdaac_forward_handler(
     prefix: str,
-    expect_tiler_message: bool,
     make_s3_object_with_prefix: Callable[[str], Object],
     sqs_queue: Queue,
 ) -> None:
@@ -25,20 +24,13 @@ def test_lpdaac_forward_handler(
 
     s3_object = make_s3_object_with_prefix(prefix)
     s3_event = make_s3_event(s3_object)
-    _handler(s3_event, lpdaac_queue_url=sqs_queue.url, tiler_queue_url=sqs_queue.url)
+    _handler(s3_event, lpdaac_queue_url=sqs_queue.url)
 
-    bucket = s3_event["Records"][0]["s3"]["bucket"]["name"]  # type: ignore
-    key = s3_event["Records"][0]["s3"]["object"]["key"]  # type: ignore
     messages = {
         message.body for message in sqs_queue.receive_messages(MaxNumberOfMessages=10)
     }
     expected_messages = {
         s3_object.get()["Body"].read().decode("utf-8"),
-        *(
-            [f"s3://{bucket}/{key.replace('.json', '_stac.json')}"]
-            if expect_tiler_message
-            else []
-        ),
     }
 
     assert messages == expected_messages

--- a/tests/unit/test_forward_stack.py
+++ b/tests/unit/test_forward_stack.py
@@ -18,7 +18,6 @@ def test_lambda_environment(s3_bucket: "Bucket", sqs_queue: "Queue"):
         "forward-notification",
         bucket_name=s3_bucket.name,
         lpdaac_queue_arn=sqs_queue.attributes["QueueArn"],
-        tiler_queue_arn=sqs_queue.attributes["QueueArn"],
     )
 
     template = Template.from_stack(stack)
@@ -41,7 +40,6 @@ def test_lambda_environment(s3_bucket: "Bucket", sqs_queue: "Queue"):
             "Environment": {
                 "Variables": {
                     "LPDAAC_QUEUE_URL": Match.object_like({"Fn::Join": args}),
-                    "TILER_QUEUE_URL": Match.object_like({"Fn::Join": args}),
                 }
             }
         },


### PR DESCRIPTION
## Description

As part of completing https://github.com/NASA-IMPACT/hls_development/issues/169 we migrated the dynamic raster tiling service for HLS from an in-house deployment of TiTiler to one running TiTiler CMR (ref https://www.earthdata.nasa.gov/news/blog/visualizing-earth-data-demand-nasas-titiler-cmr-delivers-imagery-without-wait).

On ~Nov 13, 2025 we took down the old stack running TiTiler + PgSTAC. This included deletion of the "tiler queue" that received messages from this `hls-lpdaac` forwarding service.

Since the tiler queue was deleted and our forwarding Lambda sent messages to both LPDAAC and the tiler queue, starting on ~Nov 13, 2025 the Lambda functions would always fail when handling HLS granules. This Lambda would be retried 2x times before giving up, causing 3 duplicate messages to be sent to LPDAAC.

This PR removes the code related to the tiler queue to resolve this issue.